### PR TITLE
Support CocoaPods 1.11.x

### DIFF
--- a/lib/xcframework_converter.rb
+++ b/lib/xcframework_converter.rb
@@ -64,7 +64,7 @@ module XCFrameworkConverter
       end
       Xcodeproj::Plist.write_to_path(plist, xcframework_path.join('Info.plist'))
       FileUtils.rm_rf(path)
-      final_framework = Pod::Xcode::XCFramework.new(xcframework_path.realpath)
+      final_framework = Pod::Xcode::XCFramework.new(File.basename(path, '.framework'), xcframework_path.realpath)
       final_framework.slices.each do |slice|
         patch_arm_binary(slice) if slice.platform == :ios && slice.platform_variant == :simulator
         cleanup_unused_archs(slice)

--- a/xcframework_converter.gemspec
+++ b/xcframework_converter.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables   = ['xcfconvert']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'cocoapods', '>= 1.10.0', '~> 1'
+  spec.add_runtime_dependency 'cocoapods', '>= 1.11.0', '~> 1'
   spec.add_runtime_dependency 'xcodeproj', '>= 1.20.0', '~> 1'
 end


### PR DESCRIPTION
### Issue

When executing `xcfconvert`  with CocoaPods >= 1.11.0, it will error:

```
/Users/elfsundae/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/cocoapods-1.11.2/lib/cocoapods/xcode/xcframework.rb:35:in `initialize': wrong number of arguments (given 1, expected 2) (ArgumentError)
	from /Users/elfsundae/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/xcframework_converter-0.1.2/lib/xcframework_converter.rb:67:in `new'
	from /Users/elfsundae/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/xcframework_converter-0.1.2/lib/xcframework_converter.rb:67:in `convert_framework_to_xcframework'
	from /Users/elfsundae/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/xcframework_converter-0.1.2/bin/xcfconvert:12:in `<top (required)>'
	from /Users/elfsundae/.rbenv/versions/2.6.8/bin/xcfconvert:23:in `load'
	from /Users/elfsundae/.rbenv/versions/2.6.8/bin/xcfconvert:23:in `<main>'
```

### Reason

After CocoaPods 1.11.0, `Pod::Xcode::XCFramework.initialize()` requires an additional parameter `target_name`.

### Fixes

- Increase the CocoaPods dependency to `>= 1.11.0`
- Pass `File.basename(path, '.framework')` as `target_name` to the `Pod::Xcode::XCFramework.new()` method.
