### PR TITLE
Fix various `ar` unix horrors

### DIFF
--- a/lib/xcframework_converter/arm_patcher.rb
+++ b/lib/xcframework_converter/arm_patcher.rb
@@ -63,29 +63,26 @@ module XCFrameworkConverter
         `xcrun lipo \"#{slice.binary_path}\" -thin arm64 -output \"#{extracted_path}\"`
         extracted_path_dir = slice.path.join('arm64-objects')
         extracted_path_dir.mkdir        
-        object_files = `ar t \"#{extracted_path}\"`.split("\n").map(&:chomp).sort.select { |o| o.end_with?('.o') }.tally
+        object_files = `ar t \"#{extracted_path}\"`.split("\n").map(&:chomp).sort.select { |o| o.end_with?('.o') }.group_by(&:itself).transform_values(&:count)
         processed_files = []
         index = 0
         while object_files.any? do
           object_files.keys.each do |object_file|
             file_shard = Digest::MD5.hexdigest(object_file).to_s[0..2]
             file_dir = extracted_path_dir.join("#{index}-#{file_shard}")
+            file_path = file_dir.join(object_file)
             file_dir.mkdir unless file_dir.exist?
-            `ar p \"#{extracted_path}\" \"#{object_file}\" > \"#{file_dir.join(object_file)}\"`
+            `ar p \"#{extracted_path}\" \"#{object_file}\" > \"#{file_path}\"`
+            macho_file = MachO::MachOFile.new(file_path)
+            sdk_version = macho_file[:LC_VERSION_MIN_IPHONEOS].first.version_string.to_i
+            `\"#{arm2sim_path}\" \"#{file_path}\" \"#{sdk_version}\" \"#{sdk_version}\"`  
             $stderr.printf '.'
-            processed_files << file_dir.join(object_file)
+            processed_files << file_path
           end
           `ar d \"#{extracted_path}\" #{object_files.keys.map(&:shellescape).join(' ')}`
           $stderr.printf '#'
           object_files.reject! { |_, count| count <= index + 1 }
           index += 1
-        end
-        $stderr.puts
-        extracted_path_dir.glob('*/*.o').sort.each do |object_file|
-          file = MachO::MachOFile.new(object_file)
-          sdk_version = file[:LC_VERSION_MIN_IPHONEOS].first.version_string.to_i
-          `\"#{arm2sim_path}\" \"#{object_file}\" \"#{sdk_version}\" \"#{sdk_version}\"`
-          $stderr.printf '.'
         end
         $stderr.puts
         `cd \"#{extracted_path_dir}\" ; ar cqv \"#{extracted_path}\" #{processed_files.map(&:shellescape).join(' ')}`


### PR DESCRIPTION
* The original `ar` file format does not support file paths, only file names. GNU ar supports paths but macOS doesn't have it.
* It's possible to add multiple different files with the same name to an `ar` archive and the linker accepts this.
* When extracting using `ar x`, the files with the same filename overwrite each other so only one ends up extracted.
* This overwrite also happens with files that have differently cased names because macOS isn't case-sensitive (e.g. `Initialize.cpp.o` and `initialize.cpp.o`).
* It's not possible to extract these separate file instances by using `ar` directly. Only possible by a hack, e.g. extracting the first one using `ar p` and then removing it using `ar d` in a loop.
* Adding files to an archive using `ar crv` also conflates the different copies that have the same name. To append, `ar cqv` needs to be used.
