### PR TITLE
feat: Add support for Podfile defined platform

### DIFF
--- a/lib/xcframework_converter.rb
+++ b/lib/xcframework_converter.rb
@@ -17,7 +17,7 @@ require 'xcodeproj'
 # dylibs: https://bogo.wtf/arm64-to-sim-dylibs.html
 module XCFrameworkConverter
   class << self
-    def convert_frameworks_to_xcframeworks!(installer, platform_name = "ios")
+    def convert_frameworks_to_xcframeworks!(installer, current_platform = :ios)
       installer.analysis_result.specifications.each do |spec|
         next if spec.source && spec.local?
 
@@ -29,7 +29,7 @@ module XCFrameworkConverter
                   .map { |f| pod_path.join(f) }
         end.flatten.uniq
 
-        patch_xcframeworks_if_needed(xcframeworks_to_patch, platform_name)
+        patch_xcframeworks_if_needed(xcframeworks_to_patch, current_platform)
 
         frameworks_to_convert = spec.available_platforms.map do |platform|
           consumer = Pod::Specification::Consumer.new(spec, platform)
@@ -42,7 +42,7 @@ module XCFrameworkConverter
           before_rename.map { |f| pod_path.join(f) }
         end.flatten.uniq
 
-        convert_xcframeworks_if_present(frameworks_to_convert, platform_name)
+        convert_xcframeworks_if_present(frameworks_to_convert, current_platform)
 
         remember_spec_as_patched(spec) unless frameworks_to_convert.empty?
 
@@ -52,15 +52,15 @@ module XCFrameworkConverter
       warn "Specs with patched XCFrameworks: #{@patched_specs.sort.join(', ')}"
     end
 
-    def convert_xcframeworks_if_present(frameworks_to_convert, platform_name)
+    def convert_xcframeworks_if_present(frameworks_to_convert, current_platform)
       frameworks_to_convert.each do |path|
-        convert_framework_to_xcframework(path, platform_name) if Dir.exist?(path)
+        convert_framework_to_xcframework(path, current_platform) if Dir.exist?(path)
       end
     end
 
-    def patch_xcframeworks_if_needed(xcframeworks, platform_name)
+    def patch_xcframeworks_if_needed(xcframeworks, current_platform)
       xcframeworks.each do |path|
-        patch_xcframework(path, platform_name) if Dir.exist?(path)
+        patch_xcframework(path, current_platform) if Dir.exist?(path)
       end
     end
 

--- a/lib/xcframework_converter.rb
+++ b/lib/xcframework_converter.rb
@@ -17,7 +17,7 @@ require 'xcodeproj'
 # dylibs: https://bogo.wtf/arm64-to-sim-dylibs.html
 module XCFrameworkConverter
   class << self
-    def convert_frameworks_to_xcframeworks!(installer)
+    def convert_frameworks_to_xcframeworks!(installer, platform_name = "ios")
       installer.analysis_result.specifications.each do |spec|
         next if spec.source && spec.local?
 
@@ -29,7 +29,7 @@ module XCFrameworkConverter
                   .map { |f| pod_path.join(f) }
         end.flatten.uniq
 
-        patch_xcframeworks_if_needed(xcframeworks_to_patch)
+        patch_xcframeworks_if_needed(xcframeworks_to_patch, platform_name)
 
         frameworks_to_convert = spec.available_platforms.map do |platform|
           consumer = Pod::Specification::Consumer.new(spec, platform)
@@ -42,7 +42,7 @@ module XCFrameworkConverter
           before_rename.map { |f| pod_path.join(f) }
         end.flatten.uniq
 
-        convert_xcframeworks_if_present(frameworks_to_convert)
+        convert_xcframeworks_if_present(frameworks_to_convert, platform_name)
 
         remember_spec_as_patched(spec) unless frameworks_to_convert.empty?
 
@@ -52,15 +52,15 @@ module XCFrameworkConverter
       warn "Specs with patched XCFrameworks: #{@patched_specs.sort.join(', ')}"
     end
 
-    def convert_xcframeworks_if_present(frameworks_to_convert)
+    def convert_xcframeworks_if_present(frameworks_to_convert, platform_name)
       frameworks_to_convert.each do |path|
-        convert_framework_to_xcframework(path) if Dir.exist?(path)
+        convert_framework_to_xcframework(path, platform_name) if Dir.exist?(path)
       end
     end
 
-    def patch_xcframeworks_if_needed(xcframeworks)
+    def patch_xcframeworks_if_needed(xcframeworks, platform_name)
       xcframeworks.each do |path|
-        patch_xcframework(path) if Dir.exist?(path)
+        patch_xcframework(path, platform_name) if Dir.exist?(path)
       end
     end
 

--- a/lib/xcframework_converter/arm_patcher.rb
+++ b/lib/xcframework_converter/arm_patcher.rb
@@ -25,6 +25,7 @@ module XCFrameworkConverter
         when :static
           patch_arm_binary_static(slice)
         end
+
         slice.path.glob('**/arm64*.swiftinterface').each do |interface_file|
           `sed -i '' -E 's/target arm64-apple-ios([0-9.]+) /target arm64-apple-ios\\1-simulator /g' "#{interface_file}"`
         end

--- a/lib/xcframework_converter/arm_patcher.rb
+++ b/lib/xcframework_converter/arm_patcher.rb
@@ -36,12 +36,6 @@ module XCFrameworkConverter
         extracted_path = slice.path.join('arm64.dylib')
         `xcrun lipo \"#{slice.binary_path}\" -thin arm64 -output \"#{extracted_path}\"`
 
-        file = MachO::MachOFile.new(extracted_path)
-        first_object = file[:LC_VERSION_MIN_IPHONEOS].first
-        sdk_version = "1.0.0"
-        unless first_object.nil? || first_object == 0
-          sdk_version = first_object.version_string
-        end
         minos_version, sdk_version = version_strings(extracted_path).map(&:to_i)
         `xcrun vtool -arch arm64 -set-build-version 7 #{minos_version} #{sdk_version} -replace -output \"#{extracted_path}\" \"#{extracted_path}\"`
 

--- a/lib/xcframework_converter/arm_patcher.rb
+++ b/lib/xcframework_converter/arm_patcher.rb
@@ -25,6 +25,7 @@ module XCFrameworkConverter
         when :static
           patch_arm_binary_static(slice)
         end
+        
         slice.path.glob('**/arm64*.swiftinterface').each do |interface_file|
           `sed -i '' -E 's/target arm64-apple-ios([0-9.]+) /target arm64-apple-ios\\1-simulator /g' "#{interface_file}"`
         end

--- a/lib/xcframework_converter/arm_patcher.rb
+++ b/lib/xcframework_converter/arm_patcher.rb
@@ -25,7 +25,6 @@ module XCFrameworkConverter
         when :static
           patch_arm_binary_static(slice)
         end
-        
         slice.path.glob('**/arm64*.swiftinterface').each do |interface_file|
           `sed -i '' -E 's/target arm64-apple-ios([0-9.]+) /target arm64-apple-ios\\1-simulator /g' "#{interface_file}"`
         end

--- a/lib/xcframework_converter/arm_patcher.rb
+++ b/lib/xcframework_converter/arm_patcher.rb
@@ -38,7 +38,6 @@ module XCFrameworkConverter
 
         minos_version, sdk_version = version_strings(extracted_path).map(&:to_i)
         `xcrun vtool -arch arm64 -set-build-version 7 #{minos_version} #{sdk_version} -replace -output \"#{extracted_path}\" \"#{extracted_path}\"`
-
         `xcrun lipo \"#{slice.binary_path}\" -replace arm64 \"#{extracted_path}\" -output \"#{slice.binary_path}\"`
         extracted_path.rmtree
       end

--- a/lib/xcframework_converter/creation.rb
+++ b/lib/xcframework_converter/creation.rb
@@ -20,16 +20,16 @@ module XCFrameworkConverter
       Pathname.new(__FILE__).dirname.join('../xcframework_template.plist')
     end
 
-    def convert_framework_to_xcframework(path, platform_name)
+    def convert_framework_to_xcframework(path, current_platform)
       plist = Xcodeproj::Plist.read_from_path(plist_template_path)
       xcframework_path = Pathname.new(path).sub_ext('.xcframework')
       xcframework_path.mkdir
       plist['AvailableLibraries'].each do |slice|
-        slice_library_identifier = slice['LibraryIdentifier'].sub("platform", "#{platform_name}")
+        slice_library_identifier = slice['LibraryIdentifier'].sub("platform", "#{current_platform.name}")
         slice_path = xcframework_path.join(slice_library_identifier)
         slice_path.mkdir
         slice['LibraryPath'] = File.basename(path)
-        slice['SupportedPlatform'] = platform_name
+        slice['SupportedPlatform'] = current_platform.name
         slice['LibraryIdentifier'] = slice_library_identifier
         FileUtils.cp_r(path, slice_path)
       end
@@ -37,7 +37,7 @@ module XCFrameworkConverter
       FileUtils.rm_rf(path)
       final_framework = Pod::Xcode::XCFramework.open_xcframework(xcframework_path)
       final_framework.slices.each do |slice|
-        ArmPatcher.patch_arm_binary(slice) if slice.platform.name == platform_name && slice.platform_variant == :simulator
+        ArmPatcher.patch_arm_binary(slice) if slice.platform == current_platform && slice.platform_variant == :simulator
         ArmPatcher.cleanup_unused_archs(slice)
       end
     end

--- a/lib/xcframework_converter/patching.rb
+++ b/lib/xcframework_converter/patching.rb
@@ -20,13 +20,13 @@ module XCFrameworkConverter
       xcframework = Pod::Xcode::XCFramework.open_xcframework(xcframework_path)
 
       return nil if xcframework.slices.any? do |slice|
-        slice.platform == current_platform &&
+        slice.platform.name == current_platform.name &&
         slice.platform_variant == :simulator &&
         slice.supported_archs.include?('arm64')
       end
 
       original_arm_slice_identifier = xcframework.slices.find do |slice|
-        slice.platform == current_platform && slice.supported_archs.include?('arm64')
+        slice.platform.name == current_platform.name && slice.supported_archs.include?('arm64')
       end.identifier
 
       patched_arm_slice_identifier = "#{current_platform.name}-arm64-simulator"

--- a/lib/xcframework_converter/patching.rb
+++ b/lib/xcframework_converter/patching.rb
@@ -16,20 +16,20 @@ require 'xcodeproj'
 # dylibs: https://bogo.wtf/arm64-to-sim-dylibs.html
 module XCFrameworkConverter
   class << self
-    def patch_xcframework(xcframework_path)
+    def patch_xcframework(xcframework_path, platform_name)
       xcframework = Pod::Xcode::XCFramework.open_xcframework(xcframework_path)
 
       return nil if xcframework.slices.any? do |slice|
-        slice.platform == :ios &&
+        slice.platform.name == platform_name &&
         slice.platform_variant == :simulator &&
         slice.supported_archs.include?('arm64')
       end
 
       original_arm_slice_identifier = xcframework.slices.find do |slice|
-        slice.platform == :ios && slice.supported_archs.include?('arm64')
+        slice.platform.name == platform_name && slice.supported_archs.include?('arm64')
       end.identifier
 
-      patched_arm_slice_identifier = 'ios-arm64-simulator'
+      patched_arm_slice_identifier = "#{platform_name}-arm64-simulator"
 
       warn "Will patch #{xcframework_path}: #{original_arm_slice_identifier} -> #{patched_arm_slice_identifier}"
 

--- a/lib/xcframework_converter/patching.rb
+++ b/lib/xcframework_converter/patching.rb
@@ -16,20 +16,20 @@ require 'xcodeproj'
 # dylibs: https://bogo.wtf/arm64-to-sim-dylibs.html
 module XCFrameworkConverter
   class << self
-    def patch_xcframework(xcframework_path, platform_name)
+    def patch_xcframework(xcframework_path, current_platform)
       xcframework = Pod::Xcode::XCFramework.open_xcframework(xcframework_path)
 
       return nil if xcframework.slices.any? do |slice|
-        slice.platform.name == platform_name &&
+        slice.platform == current_platform &&
         slice.platform_variant == :simulator &&
         slice.supported_archs.include?('arm64')
       end
 
       original_arm_slice_identifier = xcframework.slices.find do |slice|
-        slice.platform.name == platform_name && slice.supported_archs.include?('arm64')
+        slice.platform == current_platform && slice.supported_archs.include?('arm64')
       end.identifier
 
-      patched_arm_slice_identifier = "#{platform_name}-arm64-simulator"
+      patched_arm_slice_identifier = "#{current_platform.name}-arm64-simulator"
 
       warn "Will patch #{xcframework_path}: #{original_arm_slice_identifier} -> #{patched_arm_slice_identifier}"
 

--- a/lib/xcframework_template.plist
+++ b/lib/xcframework_template.plist
@@ -6,7 +6,7 @@
 	<array>
 		<dict>
 			<key>LibraryIdentifier</key>
-			<string>ios-arm64_x86_64-simulator</string>
+			<string>platform-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
 			<string>Placeholder.framework</string>
 			<key>SupportedArchitectures</key>
@@ -21,7 +21,7 @@
 		</dict>
 		<dict>
 			<key>LibraryIdentifier</key>
-			<string>ios-arm64_armv7</string>
+			<string>platform-arm64_armv7</string>
 			<key>LibraryPath</key>
 			<string>Placeholder.framework</string>
 			<key>SupportedArchitectures</key>
@@ -30,7 +30,7 @@
 				<string>armv7</string>
 			</array>
 			<key>SupportedPlatform</key>
-			<string>ios</string>
+			<string>platform</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
Add support for the specific platform defined in Podfile (ex: `:ios`, `:tvos`).

The parameter can be passed to the `convert_frameworks_to_xcframeworks` function as `current_target_definition.platform`, default value is `:ios`

> pre_install do |installer|
>    XCFrameworkConverter.convert_frameworks_to_xcframeworks!(installer, current_target_definition.platform)
>end